### PR TITLE
#1 Question: Use of user-defined implicit conversion operators

### DIFF
--- a/console/ConsoleCalculator.cs
+++ b/console/ConsoleCalculator.cs
@@ -49,13 +49,13 @@ namespace RamanM.Properti.Calculator.Console
             string space = anchor.Namespace;
             var operations = from t in anchor.Assembly.GetTypes()
                              where t.IsClass && t.Namespace == space
-                                 && !t.Name.Contains("Operation") && !t.Name.Contains("Constant")
+                                 && !t.Name.Contains("Operation") && !t.Name.Contains("Constant") && !t.Name.StartsWith("<>c__")
                              select t;
 
             console.WriteLine();
             console.Color = ConsoleColor.White;
             console.Write("Defined operations: ");
-            console.Color = ConsoleColor.Blue; //Magenta;
+            console.Color = ConsoleColor.Blue;
             operations.ToList().ForEach(t => console.Write(t.Name + ", "));
 
             var cursor = console.GetCursor();

--- a/console/Program.cs
+++ b/console/Program.cs
@@ -89,7 +89,7 @@ internal class Program
         {
             console.SetCursor(start.Left, start.Top);
             EnsureScrolling(console, ref start.Top);
-            expression = ReadLine(console, expression); //console.ReadLine();
+            expression = ReadLine(console, expression);
             console.ResetColor();
         }
         return expression;
@@ -122,7 +122,6 @@ internal class Program
 
         var fitnessTypes = refAsm.GetTypes()
             .Where(t => t.Namespace?.Contains(".Fitness") ?? false)
-            //.Select(t => t.Name)
             .ToArray();
         string[] actions = fitnessTypes
             .Select(t => t.Name)
@@ -406,15 +405,13 @@ internal class Program
 
     public static string ReadLine(IConsoleService console, string defaultText, string caret = "> ")
     {
-        //console.WriteLine(); // make sure we're on a fresh line
         List<char> buffer = defaultText.ToCharArray().Take(console.WindowWidth - caret.Length - 1).ToList();
         console.Color = ConsoleColor.DarkBlue;
         console.Write(caret);
         console.Color = ConsoleColor.Blue;
         console.Write(new string(buffer.ToArray()));
-        //console.SetCursor(console.CursorLeft, console.CursorTop);
 
-        ConsoleKeyInfo info = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false); //console.ReadKey(true);
+        ConsoleKeyInfo info = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
         while (info.Key != ConsoleKey.Enter)
         {
             info = console.ReadKey(true);

--- a/console/Roslyn/RoslynService.cs
+++ b/console/Roslyn/RoslynService.cs
@@ -60,8 +60,7 @@ namespace RamanM.Properti.Calculator.Console.Roslyn
         public CompilerResults CompileAssembly(CompilerParameters options, string[] sources, string[] references = null)
         {
             var defaultRefs = new[] {
-                typeof(object).Assembly.Location, // System.Runtime.dll, namespace System
-                //typeof(Enumerable).Assembly.Location // System.Linq.dll
+                typeof(object).Assembly.Location,
             };
             var refs = references ?? defaultRefs;
             foreach (string dllPath in refs)

--- a/console/Roslyn/Test1.csharp
+++ b/console/Roslyn/Test1.csharp
@@ -1,6 +1,4 @@
-﻿//using System;
-
-namespace RoslynTests
+﻿namespace RoslynTests
 {
     public class Test1
     {

--- a/console/Roslyn/Test2.csharp
+++ b/console/Roslyn/Test2.csharp
@@ -1,6 +1,4 @@
-﻿//using System;
-
-namespace RoslynTests
+﻿namespace RoslynTests
 {
     public class Test2
     {

--- a/src/Calculator/Implementations/BinaryOperation.cs
+++ b/src/Calculator/Implementations/BinaryOperation.cs
@@ -63,6 +63,8 @@ namespace RamanM.Properti.Calculator.Implementations
         object IResultant.ToResult() => ToResult();
 
         public override string ToString() => ToResult().ToString();
+
+        //public static implicit operator T(BinaryOperation<T> operation) => operation.value;
     }
 
     public abstract class BinaryOperation<TOut, TIn> : BinaryOperationBase<TIn, TOut>, IBinaryOperation<TOut, TIn>
@@ -84,33 +86,33 @@ namespace RamanM.Properti.Calculator.Implementations
             Right = new Constant<TIn>(right, this);
         }
 
-        public BinaryOperation(IOperation left, IOperation right)
-            : this()
-        {
-            Left = left;
-            Right = right;
-            left.Parent = right.Parent = this;
-        }
+        //public BinaryOperation(IOperation left, IOperation right)
+        //    : this()
+        //{
+        //    Left = left;
+        //    Right = right;
+        //    left.Parent = right.Parent = this;
+        //}
 
-        public BinaryOperation(IOperation left, TIn right)
-            : this()
-        {
-            Left = left;
-            Left.Parent = this;
-            Right = new Constant<TIn>(right, this);
-        }
+        //public BinaryOperation(IOperation left, TIn right)
+        //    : this()
+        //{
+        //    Left = left;
+        //    Left.Parent = this;
+        //    Right = new Constant<TIn>(right, this);
+        //}
 
-        public BinaryOperation(TIn left, IOperation right)
-            : this()
-        {
-            Left = new Constant<TIn>(left, this);
-            Right = right;
-            Right.Parent = this;
-        }
+        //public BinaryOperation(TIn left, IOperation right)
+        //    : this()
+        //{
+        //    Left = new Constant<TIn>(left, this);
+        //    Right = right;
+        //    Right.Parent = this;
+        //}
 
-        public BinaryOperation(IOperation<TIn> left, IOperation<TIn> right)
-            : this((IOperation)left, right)
-        { }
+        //public BinaryOperation(IOperation<TIn> left, IOperation<TIn> right)
+        //    : this((IOperation)left, right)
+        //{ }
 
         protected TOut? value;
 

--- a/src/Calculator/Implementations/BinaryOperation.cs
+++ b/src/Calculator/Implementations/BinaryOperation.cs
@@ -1,26 +1,76 @@
 ﻿using RamanM.Properti.Calculator.Interfaces;
+using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public abstract class BinaryOperation<T> : BinaryOperationBase<T, T>, IBinaryOperation<T>
+    public abstract class BinaryOperation<T> : BinaryOperation<T, T>, IBinaryOperation<T>
         where T : struct
     {
         protected BinaryOperation()
-        {
-            value = null;
-            Left = null;
-            Right = null;
-            Parent = null;
-        }
+            : base() { }
 
+        //public BinaryOperation(T left, T right)
+        //    : this()
+        //{
+        //    Left = new Constant<T>(left, this);
+        //    Right = new Constant<T>(right, this);
+        //}
+
+        //public BinaryOperation(IOperation left, IOperation right)
+        //    : this()
+        //{
+        //    Left = left;
+        //    Right = right;
+        //    left.Parent = right.Parent = this;
+        //}
+
+        //public BinaryOperation(IOperation left, T right)
+        //    : this()
+        //{
+        //    Left = left;
+        //    Left.Parent = this;
+        //    Right = new Constant<T>(right, this);
+        //}
+
+        //public BinaryOperation(T left, IOperation right)
+        //    : this()
+        //{
+        //    Left = new Constant<T>(left, this);
+        //    Right = right;
+        //    Right.Parent = this;
+        //}
+
+        //public BinaryOperation(IOperation<T> left, IOperation<T> right)
+        //    : this((IOperation)left, right)
+        //{ }
         public BinaryOperation(T left, T right)
             : this()
         {
-            Left = new Constant<T>(left, this);
-            Right = new Constant<T>(right, this);
+            Left = new Operation<T>(left, this);
+            Right = new Operation<T>(right, this);
         }
 
-        public BinaryOperation(IOperation left, IOperation right)
+        //public UnaryOperation(Operation operation)
+        //    : this()
+        //{
+        //    Operand = operation;
+        //    Operand.Parent = this;
+        //}
+        //public BinaryOperation(Operation left, Operation right)
+        //    : this()
+        //{
+        //    Left = left;
+        //    Right = right;
+        //    left.Parent = right.Parent = this;
+        //}
+
+        //public UnaryOperation(Operation<T> operation)
+        //    : this()
+        //{
+        //    Operand = operation;
+        //    Operand.Parent = this;
+        //}
+        public BinaryOperation(Operation left, Operation right)
             : this()
         {
             Left = left;
@@ -28,54 +78,100 @@ namespace RamanM.Properti.Calculator.Implementations
             left.Parent = right.Parent = this;
         }
 
-        public BinaryOperation(IOperation left, T right)
-            : this()
-        {
-            Left = left;
-            Left.Parent = this;
-            Right = new Constant<T>(right, this);
-        }
+        //public BinaryOperation(Operation<T> left, Operation<T> right)
+        //    : this()
+        //{
+        //    Left = left;
+        //    Right = right;
+        //    left.Parent = right.Parent = this;
+        //}
 
-        public BinaryOperation(T left, IOperation right)
-            : this()
-        {
-            Left = new Constant<T>(left, this);
-            Right = right;
-            Right.Parent = this;
-        }
 
-        public BinaryOperation(IOperation<T> left, IOperation<T> right)
-            : this((IOperation)left, right)
-        { }
+        //protected T? getter;
 
-        protected T? value;
+        //public override IOperation Left { get; protected set; }
+        //public override IOperation Right { get; protected set; }
+        //public override IOperation Parent { get; set; }
 
-        public override IOperation Left { get; protected set; }
-        public override IOperation Right { get; protected set; }
-        public override IOperation Parent { get; set; }
+        //public string Print() => Print(ref getter);
 
-        public string Print() => Print(ref value);
+        //public string PrintSentence() => PrintSentence(ref getter);
 
-        public string PrintSentence() => PrintSentence(ref value);
-
-        public T ToResult() => ToResult(ref value);
-
-        object IResultant.ToResult() => ToResult();
-
-        public override string ToString() => ToResult().ToString();
-
-        //public static implicit operator T(BinaryOperation<T> operation) => operation.value;
+        //public T ToResult() => ToResult(ref getter);
     }
 
-    public abstract class BinaryOperation<TOut, TIn> : BinaryOperationBase<TIn, TOut>, IBinaryOperation<TOut, TIn>
-        where TOut : struct
+    //public abstract class BinaryOperation<TOut, TIn> : BinaryOperationBase<TIn, TOut>, IBinaryOperation<TOut, TIn>
+    //    where TOut : struct
+    //    where TIn : struct
+    //{
+    //    protected BinaryOperation()
+    //    {
+    //        getter = null;
+    //        Left = null;
+    //        Right = null;
+    //        Parent = null;
+    //    }
+
+    //    public BinaryOperation(TIn left, TIn right)
+    //        : this()
+    //    {
+    //        Left = new Constant<TIn>(left, this);
+    //        Right = new Constant<TIn>(right, this);
+    //    }
+
+    //    //public BinaryOperation(IOperation left, IOperation right)
+    //    //    : this()
+    //    //{
+    //    //    Left = left;
+    //    //    Right = right;
+    //    //    left.Parent = right.Parent = this;
+    //    //}
+
+    //    //public BinaryOperation(IOperation left, TIn right)
+    //    //    : this()
+    //    //{
+    //    //    Left = left;
+    //    //    Left.Parent = this;
+    //    //    Right = new Constant<TIn>(right, this);
+    //    //}
+
+    //    //public BinaryOperation(TIn left, IOperation right)
+    //    //    : this()
+    //    //{
+    //    //    Left = new Constant<TIn>(left, this);
+    //    //    Right = right;
+    //    //    Right.Parent = this;
+    //    //}
+
+    //    //public BinaryOperation(IOperation<TIn> left, IOperation<TIn> right)
+    //    //    : this((IOperation)left, right)
+    //    //{ }
+
+    //    //protected TOut? getter;
+
+    //    public override IOperation Left { get; protected set; }
+    //    public override IOperation Right { get; protected set; }
+    //    public override IOperation Parent { get; set; }
+
+    //    public string Print() => Print(ref getter);
+
+    //    public string PrintSentence() => PrintSentence(ref getter);
+
+    //    public object ToResult() => ToResult(ref getter);
+
+    //    TOut IResultant<TOut>.ToResult() => ToResult(ref getter);
+
+    //    public override string ToString() => ToResult().ToString();
+    //}
+
+    public abstract class BinaryOperation<TIn, TOut> : Operation<TOut>, IBinaryOperation<TOut, TIn>
         where TIn : struct
+        where TOut : struct
     {
         protected BinaryOperation()
         {
-            value = null;
-            Left = null;
-            Right = null;
+            getter = new Lazy<object>(() => ToResult()); //new Lazy<TOut>(ToResult);
+            Left = Right = null;
             Parent = null;
         }
 
@@ -86,62 +182,21 @@ namespace RamanM.Properti.Calculator.Implementations
             Right = new Constant<TIn>(right, this);
         }
 
-        //public BinaryOperation(IOperation left, IOperation right)
-        //    : this()
-        //{
-        //    Left = left;
-        //    Right = right;
-        //    left.Parent = right.Parent = this;
-        //}
+        public BinaryOperation(Operation left, Operation right)
+            : this()
+        {
+            Left = left;
+            Right = right;
+            left.Parent = right.Parent = this;
+        }
 
-        //public BinaryOperation(IOperation left, TIn right)
-        //    : this()
-        //{
-        //    Left = left;
-        //    Left.Parent = this;
-        //    Right = new Constant<TIn>(right, this);
-        //}
+        public IOperation Left { get; protected set; }
+        public IOperation Right { get; protected set; }
 
-        //public BinaryOperation(TIn left, IOperation right)
-        //    : this()
-        //{
-        //    Left = new Constant<TIn>(left, this);
-        //    Right = right;
-        //    Right.Parent = this;
-        //}
-
-        //public BinaryOperation(IOperation<TIn> left, IOperation<TIn> right)
-        //    : this((IOperation)left, right)
-        //{ }
-
-        protected TOut? value;
-
-        public override IOperation Left { get; protected set; }
-        public override IOperation Right { get; protected set; }
-        public override IOperation Parent { get; set; }
-
-        public string Print() => Print(ref value);
-
-        public string PrintSentence() => PrintSentence(ref value);
-
-        public object ToResult() => ToResult(ref value);
-
-        TOut IResultant<TOut>.ToResult() => ToResult(ref value);
-
-        public override string ToString() => ToResult().ToString();
-    }
-
-    public abstract class BinaryOperationBase<TIn, TOut>
-        where TIn : struct
-        where TOut : struct
-    {
-        public abstract IOperation Left { get; protected set; }
-        public abstract IOperation Right { get; protected set; }
-        public abstract IOperation Parent { get; set; }
         protected abstract char Operator { get; }
         public abstract TOut Apply(TIn left, TIn right);
 
-        protected string Print(ref TOut? value)
+        public override string Print() //(ref TOut? getter)
         {
             var left = Left.Print();
             var right = Right.Print();
@@ -149,35 +204,44 @@ namespace RamanM.Properti.Calculator.Implementations
             if (Parent == null)
             {
                 format += " = {3}";
-                TOut val = value.HasValue ? value.Value : ToResult(ref value);
+                TOut val = Result(); //getter.HasValue ? getter.Value : ToResult(ref getter);
                 return string.Format(format, left, right, Operator, val); // (2 + 3) = 5
             }
             return string.Format(format, left, right, Operator); // (2 + 3)
         }
 
-        protected string PrintSentence(ref TOut? value)
+        public override string PrintSentence() //(ref TOut? getter)
         {
             var left = Left.PrintSentence();
             var right = Right.PrintSentence();
             var format = SentenceFormat();
             if (Parent == null)
             {
-                TOut val = value.HasValue ? value.Value : ToResult(ref value);
+                TOut val = Result(); //getter.HasValue ? getter.Value : ToResult(ref getter);
                 format += " is {2}";
                 return string.Format(format, left, right, val);
             }
             return string.Format(format, left, right);
         }
 
-        protected TOut ToResult(ref TOut? value)
+        public override /*TOut*/ object ToResult() //(ref TOut? getter)
         {
-            if (!value.HasValue)
-            {
-                TIn l = ((IResultant<TIn>)Left).ToResult();
-                TIn r = ((IResultant<TIn>)Right).ToResult();
-                value = Apply(l, r);
-            }
-            return value.Value;
+            //if (!getter.HasValue)
+            //{
+            TOut result = Result();
+            //getter = Apply(l, r);
+            //}
+            //return getter.Value;
+            return result;
+        }
+
+        private TOut Result()
+        {
+            var lv = Left.ToResult();
+            var rv = Right.ToResult();
+            TIn l = (TIn)Convert.ChangeType(lv, typeof(TIn)); //((IResultant<TIn>)Left).ToResult();
+            TIn r = (TIn)Convert.ChangeType(rv, typeof(TIn)); //((IResultant<TIn>)Right).ToResult();
+            return Apply(l, r);
         }
 
         /// <summary>
@@ -198,5 +262,10 @@ namespace RamanM.Properti.Calculator.Implementations
             var t = GetType();
             return t.Name.ToLower() + " of {0} and {1}";
         }
+
+        object IResultant.ToResult() => ToResult();
+
+        public override string ToString() => ToResult().ToString();
+
     }
 }

--- a/src/Calculator/Implementations/BinaryOperation.cs
+++ b/src/Calculator/Implementations/BinaryOperation.cs
@@ -9,40 +9,6 @@ namespace RamanM.Properti.Calculator.Implementations
         protected BinaryOperation()
             : base() { }
 
-        //public BinaryOperation(T left, T right)
-        //    : this()
-        //{
-        //    Left = new Constant<T>(left, this);
-        //    Right = new Constant<T>(right, this);
-        //}
-
-        //public BinaryOperation(IOperation left, IOperation right)
-        //    : this()
-        //{
-        //    Left = left;
-        //    Right = right;
-        //    left.Parent = right.Parent = this;
-        //}
-
-        //public BinaryOperation(IOperation left, T right)
-        //    : this()
-        //{
-        //    Left = left;
-        //    Left.Parent = this;
-        //    Right = new Constant<T>(right, this);
-        //}
-
-        //public BinaryOperation(T left, IOperation right)
-        //    : this()
-        //{
-        //    Left = new Constant<T>(left, this);
-        //    Right = right;
-        //    Right.Parent = this;
-        //}
-
-        //public BinaryOperation(IOperation<T> left, IOperation<T> right)
-        //    : this((IOperation)left, right)
-        //{ }
         public BinaryOperation(T left, T right)
             : this()
         {
@@ -50,26 +16,6 @@ namespace RamanM.Properti.Calculator.Implementations
             Right = new Operation<T>(right, this);
         }
 
-        //public UnaryOperation(Operation operation)
-        //    : this()
-        //{
-        //    Operand = operation;
-        //    Operand.Parent = this;
-        //}
-        //public BinaryOperation(Operation left, Operation right)
-        //    : this()
-        //{
-        //    Left = left;
-        //    Right = right;
-        //    left.Parent = right.Parent = this;
-        //}
-
-        //public UnaryOperation(Operation<T> operation)
-        //    : this()
-        //{
-        //    Operand = operation;
-        //    Operand.Parent = this;
-        //}
         public BinaryOperation(Operation left, Operation right)
             : this()
         {
@@ -77,92 +23,7 @@ namespace RamanM.Properti.Calculator.Implementations
             Right = right;
             left.Parent = right.Parent = this;
         }
-
-        //public BinaryOperation(Operation<T> left, Operation<T> right)
-        //    : this()
-        //{
-        //    Left = left;
-        //    Right = right;
-        //    left.Parent = right.Parent = this;
-        //}
-
-
-        //protected T? getter;
-
-        //public override IOperation Left { get; protected set; }
-        //public override IOperation Right { get; protected set; }
-        //public override IOperation Parent { get; set; }
-
-        //public string Print() => Print(ref getter);
-
-        //public string PrintSentence() => PrintSentence(ref getter);
-
-        //public T ToResult() => ToResult(ref getter);
     }
-
-    //public abstract class BinaryOperation<TOut, TIn> : BinaryOperationBase<TIn, TOut>, IBinaryOperation<TOut, TIn>
-    //    where TOut : struct
-    //    where TIn : struct
-    //{
-    //    protected BinaryOperation()
-    //    {
-    //        getter = null;
-    //        Left = null;
-    //        Right = null;
-    //        Parent = null;
-    //    }
-
-    //    public BinaryOperation(TIn left, TIn right)
-    //        : this()
-    //    {
-    //        Left = new Constant<TIn>(left, this);
-    //        Right = new Constant<TIn>(right, this);
-    //    }
-
-    //    //public BinaryOperation(IOperation left, IOperation right)
-    //    //    : this()
-    //    //{
-    //    //    Left = left;
-    //    //    Right = right;
-    //    //    left.Parent = right.Parent = this;
-    //    //}
-
-    //    //public BinaryOperation(IOperation left, TIn right)
-    //    //    : this()
-    //    //{
-    //    //    Left = left;
-    //    //    Left.Parent = this;
-    //    //    Right = new Constant<TIn>(right, this);
-    //    //}
-
-    //    //public BinaryOperation(TIn left, IOperation right)
-    //    //    : this()
-    //    //{
-    //    //    Left = new Constant<TIn>(left, this);
-    //    //    Right = right;
-    //    //    Right.Parent = this;
-    //    //}
-
-    //    //public BinaryOperation(IOperation<TIn> left, IOperation<TIn> right)
-    //    //    : this((IOperation)left, right)
-    //    //{ }
-
-    //    //protected TOut? getter;
-
-    //    public override IOperation Left { get; protected set; }
-    //    public override IOperation Right { get; protected set; }
-    //    public override IOperation Parent { get; set; }
-
-    //    public string Print() => Print(ref getter);
-
-    //    public string PrintSentence() => PrintSentence(ref getter);
-
-    //    public object ToResult() => ToResult(ref getter);
-
-    //    TOut IResultant<TOut>.ToResult() => ToResult(ref getter);
-
-    //    public override string ToString() => ToResult().ToString();
-    //}
 
     public abstract class BinaryOperation<TIn, TOut> : Operation<TOut>, IBinaryOperation<TOut, TIn>
         where TIn : struct
@@ -170,7 +31,7 @@ namespace RamanM.Properti.Calculator.Implementations
     {
         protected BinaryOperation()
         {
-            getter = new Lazy<object>(() => ToResult()); //new Lazy<TOut>(ToResult);
+            getter = new Lazy<object>(() => ToResult());
             Left = Right = null;
             Parent = null;
         }
@@ -196,7 +57,7 @@ namespace RamanM.Properti.Calculator.Implementations
         protected abstract char Operator { get; }
         public abstract TOut Apply(TIn left, TIn right);
 
-        public override string Print() //(ref TOut? getter)
+        public override string Print()
         {
             var left = Left.Print();
             var right = Right.Print();
@@ -204,34 +65,29 @@ namespace RamanM.Properti.Calculator.Implementations
             if (Parent == null)
             {
                 format += " = {3}";
-                TOut val = Result(); //getter.HasValue ? getter.Value : ToResult(ref getter);
+                TOut val = Result();
                 return string.Format(format, left, right, Operator, val); // (2 + 3) = 5
             }
             return string.Format(format, left, right, Operator); // (2 + 3)
         }
 
-        public override string PrintSentence() //(ref TOut? getter)
+        public override string PrintSentence()
         {
             var left = Left.PrintSentence();
             var right = Right.PrintSentence();
             var format = SentenceFormat();
             if (Parent == null)
             {
-                TOut val = Result(); //getter.HasValue ? getter.Value : ToResult(ref getter);
+                TOut val = Result();
                 format += " is {2}";
                 return string.Format(format, left, right, val);
             }
             return string.Format(format, left, right);
         }
 
-        public override /*TOut*/ object ToResult() //(ref TOut? getter)
+        public override object ToResult()
         {
-            //if (!getter.HasValue)
-            //{
             TOut result = Result();
-            //getter = Apply(l, r);
-            //}
-            //return getter.Value;
             return result;
         }
 
@@ -239,8 +95,8 @@ namespace RamanM.Properti.Calculator.Implementations
         {
             var lv = Left.ToResult();
             var rv = Right.ToResult();
-            TIn l = (TIn)Convert.ChangeType(lv, typeof(TIn)); //((IResultant<TIn>)Left).ToResult();
-            TIn r = (TIn)Convert.ChangeType(rv, typeof(TIn)); //((IResultant<TIn>)Right).ToResult();
+            TIn l = (TIn)Convert.ChangeType(lv, typeof(TIn));
+            TIn r = (TIn)Convert.ChangeType(rv, typeof(TIn));
             return Apply(l, r);
         }
 

--- a/src/Calculator/Implementations/Constant.cs
+++ b/src/Calculator/Implementations/Constant.cs
@@ -1,74 +1,20 @@
 ﻿using RamanM.Properti.Calculator.Interfaces;
-using System;
 
 namespace RamanM.Properti.Calculator.Implementations;
 
-//public class Constant //: Constant<double>, IOperation<double>, IOperation
-//{
-//}
-
-//public class Constant : Operation, IOperation, IResultant //, IResultant<double>, IResultant<int>, IResultant<long>
-//{
-//    private readonly object value;
-
-//    private Constant() { }
-
-//    //public Constant(object getter)
-//    //{
-//    //    object v = Convert.ChangeType(getter, typeof(T));
-//    //    this.getter = (T)v;
-//    //    Parent = null;
-//    //}
-
-//    //public Constant(object getter, IOperation parent)
-//    //    : this(getter)
-//    //{
-//    //    Parent = parent;
-//    //}
-
-//    //public Constant(object getter, IOperation<T> parent)
-//    //    : this(getter)
-//    //{
-//    //    Parent = (IOperation)parent;
-//    //}
-
-//    public Constant(object value) //: base(value) { }
-//    {
-//        this.value = value;
-//    }
-
-//    public Constant(object value, IOperation parent) //: base(value, parent) { }
-//    {
-//        this.value = value;
-//        Parent = parent;
-//    }
-
-//    public override string Print() => ToString();
-//    public override string PrintSentence() => ToString();
-
-//    public override object ToResult() => value;
-//    //double IResultant.ToResult() => ToResult();
-
-//    public override string ToString() => value.ToString();
-
-//    //public static implicit operator Constant<T>(double constant) => new Constant<double>(constant);
-//    //public static implicit operator Constant<T>(int constant) => new Constant<int>(constant);
-//    //public static implicit operator Constant<T>(long constant) => new Constant<long>(constant);
-//}
-
-public class Constant<T> : Operation, IOperation<T>, IOperation, IResultant //, IResultant<double>, IResultant<int>, IResultant<long>
+public class Constant<T> : Operation, IOperation<T>, IOperation, IResultant
     where T : struct
 {
-    private readonly /*object*/ T value;
+    private readonly T value;
 
     private Constant() { }
 
-    public Constant(T value) //: base(value) { }
+    public Constant(T value)
     {
         this.value = value;
     }
 
-    public Constant(T value, IOperation parent) //: base(value, parent) { }
+    public Constant(T value, IOperation parent)
     {
         this.value = value;
         Parent = parent;
@@ -76,15 +22,7 @@ public class Constant<T> : Operation, IOperation<T>, IOperation, IResultant //, 
 
     public override string Print() => ToString();
     public override string PrintSentence() => ToString();
-
     public override object ToResult() => value;
-    //double IResultant.ToResult() => ToResult();
-
     public override string ToString() => value.ToString();
-
     T IResultant<T>.ToResult() => value;
-
-    //public static implicit operator Constant<T>(double constant) => new Constant<double>(constant);
-    //public static implicit operator Constant<T>(int constant) => new Constant<int>(constant);
-    //public static implicit operator Constant<T>(long constant) => new Constant<long>(constant);
 }

--- a/src/Calculator/Implementations/Constant.cs
+++ b/src/Calculator/Implementations/Constant.cs
@@ -1,93 +1,90 @@
 ﻿using RamanM.Properti.Calculator.Interfaces;
 using System;
 
-namespace RamanM.Properti.Calculator.Implementations
+namespace RamanM.Properti.Calculator.Implementations;
+
+//public class Constant //: Constant<double>, IOperation<double>, IOperation
+//{
+//}
+
+//public class Constant : Operation, IOperation, IResultant //, IResultant<double>, IResultant<int>, IResultant<long>
+//{
+//    private readonly object value;
+
+//    private Constant() { }
+
+//    //public Constant(object getter)
+//    //{
+//    //    object v = Convert.ChangeType(getter, typeof(T));
+//    //    this.getter = (T)v;
+//    //    Parent = null;
+//    //}
+
+//    //public Constant(object getter, IOperation parent)
+//    //    : this(getter)
+//    //{
+//    //    Parent = parent;
+//    //}
+
+//    //public Constant(object getter, IOperation<T> parent)
+//    //    : this(getter)
+//    //{
+//    //    Parent = (IOperation)parent;
+//    //}
+
+//    public Constant(object value) //: base(value) { }
+//    {
+//        this.value = value;
+//    }
+
+//    public Constant(object value, IOperation parent) //: base(value, parent) { }
+//    {
+//        this.value = value;
+//        Parent = parent;
+//    }
+
+//    public override string Print() => ToString();
+//    public override string PrintSentence() => ToString();
+
+//    public override object ToResult() => value;
+//    //double IResultant.ToResult() => ToResult();
+
+//    public override string ToString() => value.ToString();
+
+//    //public static implicit operator Constant<T>(double constant) => new Constant<double>(constant);
+//    //public static implicit operator Constant<T>(int constant) => new Constant<int>(constant);
+//    //public static implicit operator Constant<T>(long constant) => new Constant<long>(constant);
+//}
+
+public class Constant<T> : Operation, IOperation<T>, IOperation, IResultant //, IResultant<double>, IResultant<int>, IResultant<long>
+    where T : struct
 {
-    //public class Constant : IOperation
-    //{
-    //    private readonly object value;
+    private readonly /*object*/ T value;
 
-    //    private Constant() { }
+    private Constant() { }
 
-    //    public Constant(object value)
-    //    {
-    //        this.value = value;
-    //        Parent = null;
-    //    }
-
-    //    public Constant(object value, IOperation parent)
-    //    {
-    //        this.value = value;
-    //        Parent = parent;
-    //    }
-
-    //    public IOperation Parent { get; set; }
-
-    //    public string Print() => value.ToString();
-
-    //    public string PrintSentence() => value.ToString();
-
-    //    public object ToResult() => value;
-
-    //    public static implicit operator Constant(double constant)
-    //        => new Constant(constant);
-    //}
-
-    public class Constant<T> : IOperation<T>
-        where T : struct
+    public Constant(T value) //: base(value) { }
     {
-        private readonly T value;
-
-        private Constant() { }
-
-        //public Constant(object value)
-        //{
-        //    object v = Convert.ChangeType(value, typeof(T));
-        //    this.value = (T)v;
-        //    Parent = null;
-        //}
-
-        //public Constant(object value, IOperation parent)
-        //    : this(value)
-        //{
-        //    Parent = parent;
-        //}
-
-        //public Constant(object value, IOperation<T> parent)
-        //    : this(value)
-        //{
-        //    Parent = (IOperation)parent;
-        //}
-
-        public Constant(T value)
-        {
-            this.value = value;
-            Parent = null;
-        }
-
-        public Constant(T value, IOperation parent)
-        {
-            this.value = value;
-            Parent = parent;
-        }
-
-        //public Constant(T value, IOperation<T> parent)
-        //{
-        //    this.value = value;
-        //    Parent = (IOperation)parent;
-        //}
-
-        public IOperation Parent { get; set; }
-
-        public string Print() => value.ToString();
-
-        public string PrintSentence() => value.ToString();
-
-        public T ToResult() => value;
-
-        object IResultant.ToResult() => ToResult();
-
-        public static implicit operator T(Constant<T> operation) => operation.value;
-        public static implicit operator Constant<T>(T constant) => new(constant);
+        this.value = value;
     }
+
+    public Constant(T value, IOperation parent) //: base(value, parent) { }
+    {
+        this.value = value;
+        Parent = parent;
+    }
+
+    public override string Print() => ToString();
+    public override string PrintSentence() => ToString();
+
+    public override object ToResult() => value;
+    //double IResultant.ToResult() => ToResult();
+
+    public override string ToString() => value.ToString();
+
+    T IResultant<T>.ToResult() => value;
+
+    //public static implicit operator Constant<T>(double constant) => new Constant<double>(constant);
+    //public static implicit operator Constant<T>(int constant) => new Constant<int>(constant);
+    //public static implicit operator Constant<T>(long constant) => new Constant<long>(constant);
 }

--- a/src/Calculator/Implementations/Constant.cs
+++ b/src/Calculator/Implementations/Constant.cs
@@ -3,32 +3,35 @@ using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Constant : IOperation
-    {
-        private readonly object value;
+    //public class Constant : IOperation
+    //{
+    //    private readonly object value;
 
-        private Constant() { }
+    //    private Constant() { }
 
-        public Constant(object value)
-        {
-            this.value = value;
-            Parent = null;
-        }
+    //    public Constant(object value)
+    //    {
+    //        this.value = value;
+    //        Parent = null;
+    //    }
 
-        public Constant(object value, IOperation parent)
-        {
-            this.value = value;
-            Parent = parent;
-        }
+    //    public Constant(object value, IOperation parent)
+    //    {
+    //        this.value = value;
+    //        Parent = parent;
+    //    }
 
-        public IOperation Parent { get; set; }
+    //    public IOperation Parent { get; set; }
 
-        public string Print() => value.ToString();
+    //    public string Print() => value.ToString();
 
-        public string PrintSentence() => value.ToString();
+    //    public string PrintSentence() => value.ToString();
 
-        public object ToResult() => value;
-    }
+    //    public object ToResult() => value;
+
+    //    public static implicit operator Constant(double constant)
+    //        => new Constant(constant);
+    //}
 
     public class Constant<T> : IOperation<T>
         where T : struct
@@ -37,24 +40,24 @@ namespace RamanM.Properti.Calculator.Implementations
 
         private Constant() { }
 
-        public Constant(object value)
-        {
-            object v = Convert.ChangeType(value, typeof(T));
-            this.value = (T)v;
-            Parent = null;
-        }
+        //public Constant(object value)
+        //{
+        //    object v = Convert.ChangeType(value, typeof(T));
+        //    this.value = (T)v;
+        //    Parent = null;
+        //}
 
-        public Constant(object value, IOperation parent)
-            : this(value)
-        {
-            Parent = parent;
-        }
+        //public Constant(object value, IOperation parent)
+        //    : this(value)
+        //{
+        //    Parent = parent;
+        //}
 
-        public Constant(object value, IOperation<T> parent)
-            : this(value)
-        {
-            Parent = (IOperation)parent;
-        }
+        //public Constant(object value, IOperation<T> parent)
+        //    : this(value)
+        //{
+        //    Parent = (IOperation)parent;
+        //}
 
         public Constant(T value)
         {
@@ -68,11 +71,11 @@ namespace RamanM.Properti.Calculator.Implementations
             Parent = parent;
         }
 
-        public Constant(T value, IOperation<T> parent)
-        {
-            this.value = value;
-            Parent = (IOperation)parent;
-        }
+        //public Constant(T value, IOperation<T> parent)
+        //{
+        //    this.value = value;
+        //    Parent = (IOperation)parent;
+        //}
 
         public IOperation Parent { get; set; }
 
@@ -83,5 +86,8 @@ namespace RamanM.Properti.Calculator.Implementations
         public T ToResult() => value;
 
         object IResultant.ToResult() => ToResult();
+
+        public static implicit operator T(Constant<T> operation) => operation.value;
+        public static implicit operator Constant<T>(T constant) => new(constant);
     }
 }

--- a/src/Calculator/Implementations/Division.cs
+++ b/src/Calculator/Implementations/Division.cs
@@ -1,27 +1,11 @@
-﻿using RamanM.Properti.Calculator.Interfaces;
-using System;
+﻿using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Division : BinaryOperation<double> //, IResultant<int>, IResultant<long>
+    public class Division : BinaryOperation<double>
     {
         private Division() { }
 
-        //public Division(double left, double right)
-        //    : base(left, right) { }
-
-        //public Division(IOperation left, double right)
-        //    : base(left, right) { }
-        //public Division(IOperation<double> left, double right)
-        //    : base(left, right) { }
-
-        //public Division(double left, IOperation right)
-        //    : base(left, right) { }
-        //public Division(double left, IOperation<double> right)
-        //    : base(left, right) { }
-
-        //public Division(IOperation left, IOperation right)
-        //    : base(left, right) { }
         public Division(Operation left, Operation right)
             : base(left, right) { }
 
@@ -33,17 +17,10 @@ namespace RamanM.Properti.Calculator.Implementations
         protected override string SentenceFormat()
             => nameof(Division).ToLower() + " of {0} by {1}";
 
-        //int IResultant<int>.ToResult()
-        //    => Convert.ToInt32(ToResult());
         public static explicit operator int(Division operation)
             => Convert.ToInt32(operation.ToResult());
 
-        //long IResultant<long>.ToResult()
-        //    => Convert.ToInt64(ToResult());
         public static explicit operator long(Division operation)
             => Convert.ToInt64(operation.ToResult());
-
-        //public static implicit operator double(Division operation)
-        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Division.cs
+++ b/src/Calculator/Implementations/Division.cs
@@ -5,11 +5,10 @@ namespace RamanM.Properti.Calculator.Implementations
 {
     public class Division : BinaryOperation<double> //, IResultant<int>, IResultant<long>
     {
-        private Division()
-            : base() { }
+        private Division() { }
 
-        public Division(double left, double right)
-            : base(left, right) { }
+        //public Division(double left, double right)
+        //    : base(left, right) { }
 
         //public Division(IOperation left, double right)
         //    : base(left, right) { }
@@ -23,8 +22,8 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //public Division(IOperation left, IOperation right)
         //    : base(left, right) { }
-        //public Division(IOperation<double> left, IOperation<double> right)
-        //    : base(left, right) { }
+        public Division(Operation left, Operation right)
+            : base(left, right) { }
 
         protected override char Operator => '/';
 
@@ -36,15 +35,15 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //int IResultant<int>.ToResult()
         //    => Convert.ToInt32(ToResult());
-        public static implicit operator int(Division operation)
+        public static explicit operator int(Division operation)
             => Convert.ToInt32(operation.ToResult());
 
         //long IResultant<long>.ToResult()
         //    => Convert.ToInt64(ToResult());
-        public static implicit operator long(Division operation)
+        public static explicit operator long(Division operation)
             => Convert.ToInt64(operation.ToResult());
 
-        public static implicit operator double(Division operation)
-            => operation.ToResult();
+        //public static implicit operator double(Division operation)
+        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Division.cs
+++ b/src/Calculator/Implementations/Division.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Division : BinaryOperation<double>, IResultant<int>, IResultant<long>
+    public class Division : BinaryOperation<double> //, IResultant<int>, IResultant<long>
     {
         private Division()
             : base() { }
@@ -11,20 +11,20 @@ namespace RamanM.Properti.Calculator.Implementations
         public Division(double left, double right)
             : base(left, right) { }
 
-        public Division(IOperation left, double right)
-            : base(left, right) { }
-        public Division(IOperation<double> left, double right)
-            : base(left, right) { }
+        //public Division(IOperation left, double right)
+        //    : base(left, right) { }
+        //public Division(IOperation<double> left, double right)
+        //    : base(left, right) { }
 
-        public Division(double left, IOperation right)
-            : base(left, right) { }
-        public Division(double left, IOperation<double> right)
-            : base(left, right) { }
+        //public Division(double left, IOperation right)
+        //    : base(left, right) { }
+        //public Division(double left, IOperation<double> right)
+        //    : base(left, right) { }
 
-        public Division(IOperation left, IOperation right)
-            : base(left, right) { }
-        public Division(IOperation<double> left, IOperation<double> right)
-            : base(left, right) { }
+        //public Division(IOperation left, IOperation right)
+        //    : base(left, right) { }
+        //public Division(IOperation<double> left, IOperation<double> right)
+        //    : base(left, right) { }
 
         protected override char Operator => '/';
 
@@ -34,10 +34,17 @@ namespace RamanM.Properti.Calculator.Implementations
         protected override string SentenceFormat()
             => nameof(Division).ToLower() + " of {0} by {1}";
 
-        int IResultant<int>.ToResult()
-            => Convert.ToInt32(ToResult());
+        //int IResultant<int>.ToResult()
+        //    => Convert.ToInt32(ToResult());
+        public static implicit operator int(Division operation)
+            => Convert.ToInt32(operation.ToResult());
 
-        long IResultant<long>.ToResult()
-            => Convert.ToInt64(ToResult());
+        //long IResultant<long>.ToResult()
+        //    => Convert.ToInt64(ToResult());
+        public static implicit operator long(Division operation)
+            => Convert.ToInt64(operation.ToResult());
+
+        public static implicit operator double(Division operation)
+            => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Faculty.cs
+++ b/src/Calculator/Implementations/Faculty.cs
@@ -2,7 +2,7 @@
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Faculty : UnaryOperation<long>, IResultant<double>, IResultant<int>
+    public class Faculty : UnaryOperation<long> //,IResultant<double>, IResultant<int>
     {
         private Faculty()
             : base() { }
@@ -10,11 +10,11 @@ namespace RamanM.Properti.Calculator.Implementations
         public Faculty(long operand)
             : base(operand) { }
 
-        public Faculty(IOperation operation)
-            : base(operation) { }
+        //public Faculty(IOperation operation)
+        //    : base(operation) { }
 
-        public Faculty(IOperation<long> operation)
-            : base(operation) { }
+        //public Faculty(IOperation<long> operation)
+        //    : base(operation) { }
 
         protected override char Operator => '!';
 
@@ -22,10 +22,13 @@ namespace RamanM.Properti.Calculator.Implementations
             => (operand <= 1) ? 1
                 : Apply(operand - 1) * operand;
 
-        double IResultant<double>.ToResult()
-            => (double)ToResult();
+        //double IResultant<double>.ToResult()
+        //    => (double)ToResult();
+        public static implicit operator double(Faculty operation)
+            => operation.ToResult();
 
-        int IResultant<int>.ToResult()
-            => unchecked((int)ToResult());
+        //int IResultant<int>.ToResult()
+        //    => unchecked((int)ToResult());
+        public static implicit operator int(Faculty operation) => unchecked((int)(operation.ToResult()));
     }
 }

--- a/src/Calculator/Implementations/Faculty.cs
+++ b/src/Calculator/Implementations/Faculty.cs
@@ -2,18 +2,9 @@
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Faculty : UnaryOperation<long> //,IResultant<double>, IResultant<int>
+    public class Faculty : UnaryOperation<long>
     {
         private Faculty() { }
-
-        //public Faculty(long operand)
-        //    : base(operand) { }
-
-        //public Faculty(IOperation operation)
-        //    : base(operation) { }
-
-        //public Faculty(IOperation<long> operation)
-        //    : base(operation) { }
 
         public Faculty(Operation operation)
             : base(operation) { }
@@ -23,15 +14,5 @@ namespace RamanM.Properti.Calculator.Implementations
         public override long Apply(long operand)
             => (operand <= 1) ? 1
                 : Apply(operand - 1) * operand;
-
-        //double IResultant<double>.ToResult()
-        //    => (double)ToResult();
-        //public static explicit operator double(Faculty operation)
-        //    => operation.ToResult();
-
-        //int IResultant<int>.ToResult()
-        //    => unchecked((int)ToResult());
-        //public static explicit operator int(Faculty operation)
-        //    => unchecked((int)(operation.ToResult()));
     }
 }

--- a/src/Calculator/Implementations/Faculty.cs
+++ b/src/Calculator/Implementations/Faculty.cs
@@ -4,17 +4,19 @@ namespace RamanM.Properti.Calculator.Implementations
 {
     public class Faculty : UnaryOperation<long> //,IResultant<double>, IResultant<int>
     {
-        private Faculty()
-            : base() { }
+        private Faculty() { }
 
-        public Faculty(long operand)
-            : base(operand) { }
+        //public Faculty(long operand)
+        //    : base(operand) { }
 
         //public Faculty(IOperation operation)
         //    : base(operation) { }
 
         //public Faculty(IOperation<long> operation)
         //    : base(operation) { }
+
+        public Faculty(Operation operation)
+            : base(operation) { }
 
         protected override char Operator => '!';
 
@@ -24,11 +26,12 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //double IResultant<double>.ToResult()
         //    => (double)ToResult();
-        public static implicit operator double(Faculty operation)
-            => operation.ToResult();
+        //public static explicit operator double(Faculty operation)
+        //    => operation.ToResult();
 
         //int IResultant<int>.ToResult()
         //    => unchecked((int)ToResult());
-        public static implicit operator int(Faculty operation) => unchecked((int)(operation.ToResult()));
+        //public static explicit operator int(Faculty operation)
+        //    => unchecked((int)(operation.ToResult()));
     }
 }

--- a/src/Calculator/Implementations/Fraction.cs
+++ b/src/Calculator/Implementations/Fraction.cs
@@ -3,13 +3,12 @@ using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Fraction : BinaryOperation<double, int> //, IResultant<int>, IResultant<long>
+    public class Fraction : BinaryOperation<int, double> //, IResultant<int>, IResultant<long>
     {
-        private Fraction()
-            : base() { }
+        private Fraction() { }
 
-        public Fraction(int left, int right)
-            : base(left, right) { }
+        //public Fraction(int left, int right)
+        //    : base(left, right) { }
 
         //public Fraction(IOperation left, int right)
         //    : base(left, right) { }
@@ -23,8 +22,8 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //public Fraction(IOperation left, IOperation right)
         //    : base(left, right) { }
-        //public Fraction(IOperation<int> left, IOperation<int> right)
-        //    : base(left, right) { }
+        public Fraction(Operation left, Operation right)
+            : base(left, right) { }
 
         protected override char Operator => '/';
 
@@ -39,15 +38,15 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //int IResultant<int>.ToResult()
         //    => Convert.ToInt32(ToResult());
-        public static implicit operator int(Fraction operation)
+        public static explicit operator int(Fraction operation)
             => Convert.ToInt32(operation.ToResult());
 
         //long IResultant<long>.ToResult()
         //    => Convert.ToInt64(ToResult());
-        public static implicit operator long(Fraction operation)
+        public static explicit operator long(Fraction operation)
             => Convert.ToInt64(operation.ToResult());
 
-        public static implicit operator double(Fraction operation)
+        public static explicit operator double(Fraction operation)
             => (double)operation.ToResult();
         //public static implicit operator double(Fraction operation)
         //    => ((IResultant<double>)operation).ToResult();

--- a/src/Calculator/Implementations/Fraction.cs
+++ b/src/Calculator/Implementations/Fraction.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Fraction : BinaryOperation<double, int>, IResultant<int>, IResultant<long>
+    public class Fraction : BinaryOperation<double, int> //, IResultant<int>, IResultant<long>
     {
         private Fraction()
             : base() { }
@@ -11,20 +11,20 @@ namespace RamanM.Properti.Calculator.Implementations
         public Fraction(int left, int right)
             : base(left, right) { }
 
-        public Fraction(IOperation left, int right)
-            : base(left, right) { }
-        public Fraction(IOperation<int> left, int right)
-            : base(left, right) { }
+        //public Fraction(IOperation left, int right)
+        //    : base(left, right) { }
+        //public Fraction(IOperation<int> left, int right)
+        //    : base(left, right) { }
 
-        public Fraction(int left, IOperation right)
-            : base(left, right) { }
-        public Fraction(int left, IOperation<int> right)
-            : base(left, right) { }
+        //public Fraction(int left, IOperation right)
+        //    : base(left, right) { }
+        //public Fraction(int left, IOperation<int> right)
+        //    : base(left, right) { }
 
-        public Fraction(IOperation left, IOperation right)
-            : base(left, right) { }
-        public Fraction(IOperation<int> left, IOperation<int> right)
-            : base(left, right) { }
+        //public Fraction(IOperation left, IOperation right)
+        //    : base(left, right) { }
+        //public Fraction(IOperation<int> left, IOperation<int> right)
+        //    : base(left, right) { }
 
         protected override char Operator => '/';
 
@@ -37,10 +37,19 @@ namespace RamanM.Properti.Calculator.Implementations
         protected override string SentenceFormat()
             => "{0}" + Operator + "{1}";
 
-        int IResultant<int>.ToResult()
-            => Convert.ToInt32(ToResult());
+        //int IResultant<int>.ToResult()
+        //    => Convert.ToInt32(ToResult());
+        public static implicit operator int(Fraction operation)
+            => Convert.ToInt32(operation.ToResult());
 
-        long IResultant<long>.ToResult()
-            => Convert.ToInt64(ToResult());
+        //long IResultant<long>.ToResult()
+        //    => Convert.ToInt64(ToResult());
+        public static implicit operator long(Fraction operation)
+            => Convert.ToInt64(operation.ToResult());
+
+        public static implicit operator double(Fraction operation)
+            => (double)operation.ToResult();
+        //public static implicit operator double(Fraction operation)
+        //    => ((IResultant<double>)operation).ToResult();
     }
 }

--- a/src/Calculator/Implementations/Fraction.cs
+++ b/src/Calculator/Implementations/Fraction.cs
@@ -1,27 +1,11 @@
-﻿using RamanM.Properti.Calculator.Interfaces;
-using System;
+﻿using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Fraction : BinaryOperation<int, double> //, IResultant<int>, IResultant<long>
+    public class Fraction : BinaryOperation<int, double>
     {
         private Fraction() { }
 
-        //public Fraction(int left, int right)
-        //    : base(left, right) { }
-
-        //public Fraction(IOperation left, int right)
-        //    : base(left, right) { }
-        //public Fraction(IOperation<int> left, int right)
-        //    : base(left, right) { }
-
-        //public Fraction(int left, IOperation right)
-        //    : base(left, right) { }
-        //public Fraction(int left, IOperation<int> right)
-        //    : base(left, right) { }
-
-        //public Fraction(IOperation left, IOperation right)
-        //    : base(left, right) { }
         public Fraction(Operation left, Operation right)
             : base(left, right) { }
 
@@ -36,19 +20,13 @@ namespace RamanM.Properti.Calculator.Implementations
         protected override string SentenceFormat()
             => "{0}" + Operator + "{1}";
 
-        //int IResultant<int>.ToResult()
-        //    => Convert.ToInt32(ToResult());
         public static explicit operator int(Fraction operation)
             => Convert.ToInt32(operation.ToResult());
 
-        //long IResultant<long>.ToResult()
-        //    => Convert.ToInt64(ToResult());
         public static explicit operator long(Fraction operation)
             => Convert.ToInt64(operation.ToResult());
 
         public static explicit operator double(Fraction operation)
             => (double)operation.ToResult();
-        //public static implicit operator double(Fraction operation)
-        //    => ((IResultant<double>)operation).ToResult();
     }
 }

--- a/src/Calculator/Implementations/Multiplication.cs
+++ b/src/Calculator/Implementations/Multiplication.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Multiplication : BinaryOperation<double>, IResultant<int>, IResultant<long>
+    public class Multiplication : BinaryOperation<double> //, IResultant<int>, IResultant<long>
     {
         private Multiplication()
             : base() { }
@@ -11,30 +11,37 @@ namespace RamanM.Properti.Calculator.Implementations
         public Multiplication(double left, double right)
             : base(left, right) { }
 
-        public Multiplication(IOperation left, double right)
-            : base(left, right) { }
-        public Multiplication(IOperation<double> left, double right)
-            : base(left, right) { }
+        //public Multiplication(IOperation left, double right)
+        //    : base(left, right) { }
+        //public Multiplication(IOperation<double> left, double right)
+        //    : base(left, right) { }
 
-        public Multiplication(double left, IOperation right)
-            : base(left, right) { }
-        public Multiplication(double left, IOperation<double> right)
-            : base(left, right) { }
+        //public Multiplication(double left, IOperation right)
+        //    : base(left, right) { }
+        //public Multiplication(double left, IOperation<double> right)
+        //    : base(left, right) { }
 
-        public Multiplication(IOperation left, IOperation right)
-            : base(left, right) { }
-        public Multiplication(IOperation<double> left, IOperation<double> right)
-            : base(left, right) { }
+        //public Multiplication(IOperation left, IOperation right)
+        //    : base(left, right) { }
+        //public Multiplication(IOperation<double> left, IOperation<double> right)
+        //    : base(left, right) { }
 
         protected override char Operator => '*';
 
         public override double Apply(double left, double right)
             => left * right;
 
-        int IResultant<int>.ToResult()
-            => Convert.ToInt32(ToResult());
+        //int IResultant<int>.ToResult()
+        //    => Convert.ToInt32(ToResult());
+        public static implicit operator int(Multiplication operation)
+            => Convert.ToInt32(operation.ToResult());
 
-        long IResultant<long>.ToResult()
-            => Convert.ToInt64(ToResult());
+        //long IResultant<long>.ToResult()
+        //    => Convert.ToInt64(ToResult());
+        public static implicit operator long(Multiplication operation)
+            => Convert.ToInt64(operation.ToResult());
+
+        public static implicit operator double(Multiplication operation)
+            => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Multiplication.cs
+++ b/src/Calculator/Implementations/Multiplication.cs
@@ -1,27 +1,10 @@
-﻿using RamanM.Properti.Calculator.Interfaces;
-using System;
+﻿using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public class Multiplication : BinaryOperation<double> //, IResultant<int>, IResultant<long>
+    public class Multiplication : BinaryOperation<double>
     {
         private Multiplication() { }
-
-        //public Multiplication(double left, double right)
-        //    : base(left, right) { }
-
-        //public Multiplication(IOperation left, double right)
-        //    : base(left, right) { }
-        //public Multiplication(IOperation<double> left, double right)
-        //    : base(left, right) { }
-
-        //public Multiplication(double left, IOperation right)
-        //    : base(left, right) { }
-        //public Multiplication(double left, IOperation<double> right)
-        //    : base(left, right) { }
-
-        //public Multiplication(IOperation left, IOperation right)
-        //    : base(left, right) { }
 
         public Multiplication(Operation left, Operation right)
             : base(left, right) { }
@@ -31,17 +14,10 @@ namespace RamanM.Properti.Calculator.Implementations
         public override double Apply(double left, double right)
             => left * right;
 
-        //int IResultant<int>.ToResult()
-        //    => Convert.ToInt32(ToResult());
         public static explicit operator int(Multiplication operation)
             => Convert.ToInt32(operation.ToResult());
 
-        //long IResultant<long>.ToResult()
-        //    => Convert.ToInt64(ToResult());
         public static explicit operator long(Multiplication operation)
             => Convert.ToInt64(operation.ToResult());
-
-        //public static implicit operator double(Multiplication operation)
-        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Multiplication.cs
+++ b/src/Calculator/Implementations/Multiplication.cs
@@ -5,11 +5,10 @@ namespace RamanM.Properti.Calculator.Implementations
 {
     public class Multiplication : BinaryOperation<double> //, IResultant<int>, IResultant<long>
     {
-        private Multiplication()
-            : base() { }
+        private Multiplication() { }
 
-        public Multiplication(double left, double right)
-            : base(left, right) { }
+        //public Multiplication(double left, double right)
+        //    : base(left, right) { }
 
         //public Multiplication(IOperation left, double right)
         //    : base(left, right) { }
@@ -23,8 +22,9 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //public Multiplication(IOperation left, IOperation right)
         //    : base(left, right) { }
-        //public Multiplication(IOperation<double> left, IOperation<double> right)
-        //    : base(left, right) { }
+
+        public Multiplication(Operation left, Operation right)
+            : base(left, right) { }
 
         protected override char Operator => '*';
 
@@ -33,15 +33,15 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //int IResultant<int>.ToResult()
         //    => Convert.ToInt32(ToResult());
-        public static implicit operator int(Multiplication operation)
+        public static explicit operator int(Multiplication operation)
             => Convert.ToInt32(operation.ToResult());
 
         //long IResultant<long>.ToResult()
         //    => Convert.ToInt64(ToResult());
-        public static implicit operator long(Multiplication operation)
+        public static explicit operator long(Multiplication operation)
             => Convert.ToInt64(operation.ToResult());
 
-        public static implicit operator double(Multiplication operation)
-            => operation.ToResult();
+        //public static implicit operator double(Multiplication operation)
+        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Operation.cs
+++ b/src/Calculator/Implementations/Operation.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace RamanM.Properti.Calculator.Implementations;
 
-public class Operation : /*IOperation<double>,*/ IOperation
+public class Operation : IOperation
 {
     protected Lazy<object> getter;
 
@@ -49,8 +49,6 @@ public class Operation : /*IOperation<double>,*/ IOperation
 
     public override string ToString() => ToResult().ToString();
 
-    //object ToResult() => getter.Value;
-
     public static implicit operator Operation(double constant) => new Constant<double>(constant);
     public static implicit operator Operation(int constant) => new Constant<int>(constant);
     public static implicit operator Operation(long constant) => new Constant<long>(constant);
@@ -59,8 +57,6 @@ public class Operation : /*IOperation<double>,*/ IOperation
 public class Operation<T> : Operation, IOperation<T>, IOperation
     where T : struct
 {
-    //protected Lazy<T> getter;
-
     protected Operation() { }
 
     public Operation(double value)
@@ -102,8 +98,4 @@ public class Operation<T> : Operation, IOperation<T>, IOperation
     {
         return (T)ToResult();
     }
-
-    //public static implicit operator Operation<T>(double constant) => new(constant);
-    //public static implicit operator Operation<T>(int constant) => new(Convert.ToDouble(constant));
-    //public static implicit operator Operation<T>(long constant) => new(Convert.ToDouble(constant));
 }

--- a/src/Calculator/Implementations/Operation.cs
+++ b/src/Calculator/Implementations/Operation.cs
@@ -1,0 +1,109 @@
+﻿using RamanM.Properti.Calculator.Interfaces;
+using System;
+
+namespace RamanM.Properti.Calculator.Implementations;
+
+public class Operation : /*IOperation<double>,*/ IOperation
+{
+    protected Lazy<object> getter;
+
+    protected Operation() { }
+
+    public Operation(double value)
+    {
+        getter = new Lazy<object>(() => value);
+    }
+    public Operation(double value, IOperation parent)
+        : this(value)
+    {
+        Parent = parent;
+    }
+
+    public Operation(Lazy<object> getter)
+    {
+        this.getter = getter;
+    }
+    public Operation(Lazy<object> getter, IOperation parent)
+        : this(getter)
+    {
+        Parent = parent;
+    }
+
+    public Operation(Func<object> getter)
+    {
+        this.getter = new Lazy<object>(getter);
+    }
+    public Operation(Func<object> getter, IOperation parent)
+        : this(getter)
+    {
+        Parent = parent;
+    }
+
+    public IOperation Parent { get; set; }
+
+    public virtual object ToResult() => getter.Value;
+
+    public virtual string Print() => ToString();
+
+    public virtual string PrintSentence() => ToString();
+
+    public override string ToString() => ToResult().ToString();
+
+    //object ToResult() => getter.Value;
+
+    public static implicit operator Operation(double constant) => new Constant<double>(constant);
+    public static implicit operator Operation(int constant) => new Constant<int>(constant);
+    public static implicit operator Operation(long constant) => new Constant<long>(constant);
+}
+
+public class Operation<T> : Operation, IOperation<T>, IOperation
+    where T : struct
+{
+    //protected Lazy<T> getter;
+
+    protected Operation() { }
+
+    public Operation(double value)
+    {
+        getter = new Lazy<object>(() => value);
+    }
+
+    public Operation(T value)
+    {
+        getter = new Lazy<object>(() => value);
+    }
+    public Operation(T value, IOperation parent)
+        : this(value)
+    {
+        Parent = parent;
+    }
+
+    public Operation(Lazy<T> getter)
+    {
+        base.getter = new Lazy<object>(() => getter.Value);
+    }
+    public Operation(Lazy<T> getter, IOperation parent)
+        : this(getter)
+    {
+        Parent = parent;
+    }
+
+    public Operation(Func<T> getter)
+    {
+        base.getter = new Lazy<object>(() => getter.Invoke());
+    }
+    public Operation(Func<T> getter, IOperation parent)
+        : this(getter)
+    {
+        Parent = parent;
+    }
+
+    T IResultant<T>.ToResult()
+    {
+        return (T)ToResult();
+    }
+
+    //public static implicit operator Operation<T>(double constant) => new(constant);
+    //public static implicit operator Operation<T>(int constant) => new(Convert.ToDouble(constant));
+    //public static implicit operator Operation<T>(long constant) => new(Convert.ToDouble(constant));
+}

--- a/src/Calculator/Implementations/Subtraction.cs
+++ b/src/Calculator/Implementations/Subtraction.cs
@@ -8,11 +8,10 @@ namespace RamanM.Properti.Calculator.Implementations
     /// </summary>
     public class Subtraction : BinaryOperation<double> //, IResultant<int>, IResultant<long>
     {
-        private Subtraction()
-            : base() { }
+        private Subtraction() { }
 
-        public Subtraction(double left, double right)
-            : base(left, right) { }
+        //public Subtraction(double left, double right)
+        //    : base(left, right) { }
 
         //public Subtraction(IOperation left, double right)
         //   : base(left, right) { }
@@ -26,8 +25,8 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //public Subtraction(IOperation left, IOperation right)
         //   : base(left, right) { }
-        //public Subtraction(IOperation<double> left, IOperation<double> right)
-        //   : base(left, right) { }
+        public Subtraction(Operation left, Operation right)
+           : base(left, right) { }
 
         protected override char Operator => '-';
 
@@ -36,15 +35,15 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //int IResultant<int>.ToResult()
         //    => Convert.ToInt32(ToResult());
-        public static implicit operator int(Subtraction operation)
+        public static explicit operator int(Subtraction operation)
             => Convert.ToInt32(operation.ToResult());
 
         //long IResultant<long>.ToResult()
         //    => Convert.ToInt64(ToResult());
-        public static implicit operator long(Subtraction operation)
+        public static explicit operator long(Subtraction operation)
             => Convert.ToInt64(operation.ToResult());
 
-        public static implicit operator double(Subtraction operation)
-            => operation.ToResult();
+        //public static implicit operator double(Subtraction operation)
+        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Subtraction.cs
+++ b/src/Calculator/Implementations/Subtraction.cs
@@ -1,30 +1,14 @@
-﻿using RamanM.Properti.Calculator.Interfaces;
-using System;
+﻿using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
     /// <summary>
     /// Subtraction of two operations.
     /// </summary>
-    public class Subtraction : BinaryOperation<double> //, IResultant<int>, IResultant<long>
+    public class Subtraction : BinaryOperation<double>
     {
         private Subtraction() { }
 
-        //public Subtraction(double left, double right)
-        //    : base(left, right) { }
-
-        //public Subtraction(IOperation left, double right)
-        //   : base(left, right) { }
-        //public Subtraction(IOperation<double> left, double right)
-        //    : base(left, right) { }
-
-        //public Subtraction(double left, IOperation right)
-        //    : base(left, right) { }
-        //public Subtraction(double left, IOperation<double> right)
-        //    : base(left, right) { }
-
-        //public Subtraction(IOperation left, IOperation right)
-        //   : base(left, right) { }
         public Subtraction(Operation left, Operation right)
            : base(left, right) { }
 
@@ -33,17 +17,10 @@ namespace RamanM.Properti.Calculator.Implementations
         public override double Apply(double left, double right)
             => left - right;
 
-        //int IResultant<int>.ToResult()
-        //    => Convert.ToInt32(ToResult());
         public static explicit operator int(Subtraction operation)
             => Convert.ToInt32(operation.ToResult());
 
-        //long IResultant<long>.ToResult()
-        //    => Convert.ToInt64(ToResult());
         public static explicit operator long(Subtraction operation)
             => Convert.ToInt64(operation.ToResult());
-
-        //public static implicit operator double(Subtraction operation)
-        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Subtraction.cs
+++ b/src/Calculator/Implementations/Subtraction.cs
@@ -6,7 +6,7 @@ namespace RamanM.Properti.Calculator.Implementations
     /// <summary>
     /// Subtraction of two operations.
     /// </summary>
-    public class Subtraction : BinaryOperation<double>, IResultant<int>, IResultant<long>
+    public class Subtraction : BinaryOperation<double> //, IResultant<int>, IResultant<long>
     {
         private Subtraction()
             : base() { }
@@ -14,30 +14,37 @@ namespace RamanM.Properti.Calculator.Implementations
         public Subtraction(double left, double right)
             : base(left, right) { }
 
-        public Subtraction(IOperation left, double right)
-           : base(left, right) { }
-        public Subtraction(IOperation<double> left, double right)
-            : base(left, right) { }
+        //public Subtraction(IOperation left, double right)
+        //   : base(left, right) { }
+        //public Subtraction(IOperation<double> left, double right)
+        //    : base(left, right) { }
 
-        public Subtraction(double left, IOperation right)
-            : base(left, right) { }
-        public Subtraction(double left, IOperation<double> right)
-            : base(left, right) { }
+        //public Subtraction(double left, IOperation right)
+        //    : base(left, right) { }
+        //public Subtraction(double left, IOperation<double> right)
+        //    : base(left, right) { }
 
-        public Subtraction(IOperation left, IOperation right)
-           : base(left, right) { }
-        public Subtraction(IOperation<double> left, IOperation<double> right)
-           : base(left, right) { }
+        //public Subtraction(IOperation left, IOperation right)
+        //   : base(left, right) { }
+        //public Subtraction(IOperation<double> left, IOperation<double> right)
+        //   : base(left, right) { }
 
         protected override char Operator => '-';
 
         public override double Apply(double left, double right)
             => left - right;
 
-        int IResultant<int>.ToResult()
-            => Convert.ToInt32(ToResult());
+        //int IResultant<int>.ToResult()
+        //    => Convert.ToInt32(ToResult());
+        public static implicit operator int(Subtraction operation)
+            => Convert.ToInt32(operation.ToResult());
 
-        long IResultant<long>.ToResult()
-            => Convert.ToInt64(ToResult());
+        //long IResultant<long>.ToResult()
+        //    => Convert.ToInt64(ToResult());
+        public static implicit operator long(Subtraction operation)
+            => Convert.ToInt64(operation.ToResult());
+
+        public static implicit operator double(Subtraction operation)
+            => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Sum.cs
+++ b/src/Calculator/Implementations/Sum.cs
@@ -9,11 +9,10 @@ namespace RamanM.Properti.Calculator.Implementations
     /// </summary>
     public class Sum : BinaryOperation<double> //,IResultant<int>, IResultant<long>
     {
-        private Sum()
-            : base() { }
+        private Sum() { }
 
-        public Sum(double left, double right)
-            : base(left, right) { }
+        //public Sum(double left, double right)
+        //    : base(left, right) { }
 
         //public Sum(IOperation left, double right)
         //    : base(left, right) { }
@@ -27,8 +26,16 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //public Sum(IOperation left, IOperation right)
         //    : base(left, right) { }
-        //public Sum(IOperation<double> left, IOperation<double> right)
-        //    : base(left, right) { }
+
+        //public Sum(Constant<double> left, Constant<double> right)
+        //{
+        //    Left = left;
+        //    Right = right;
+        //    Parent = null;
+        //}
+
+        public Sum(Operation left, Operation right)
+            : base(left, right) { }
 
         protected override char Operator => '+';
 
@@ -37,15 +44,15 @@ namespace RamanM.Properti.Calculator.Implementations
 
         //int IResultant<int>.ToResult()
         //    => Convert.ToInt32(ToResult());
-        public static implicit operator int(Sum operation)
+        public static explicit operator int(Sum operation)
             => Convert.ToInt32(operation.ToResult());
 
         //long IResultant<long>.ToResult()
         //    => Convert.ToInt64(ToResult());
-        public static implicit operator long(Sum operation)
+        public static explicit operator long(Sum operation)
             => Convert.ToInt64(operation.ToResult());
 
-        public static implicit operator double(Sum operation)
-            => operation.ToResult();
+        //public static implicit operator double(Sum operation)
+        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Sum.cs
+++ b/src/Calculator/Implementations/Sum.cs
@@ -1,12 +1,13 @@
 ﻿using RamanM.Properti.Calculator.Interfaces;
 using System;
+using System.Reflection.Metadata;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
     /// <summary>
     /// Summation of two operations.
     /// </summary>
-    public class Sum : BinaryOperation<double>, IResultant<int>, IResultant<long>
+    public class Sum : BinaryOperation<double> //,IResultant<int>, IResultant<long>
     {
         private Sum()
             : base() { }
@@ -14,30 +15,37 @@ namespace RamanM.Properti.Calculator.Implementations
         public Sum(double left, double right)
             : base(left, right) { }
 
-        public Sum(IOperation left, double right)
-            : base(left, right) { }
-        public Sum(IOperation<double> left, double right)
-            : base(left, right) { }
+        //public Sum(IOperation left, double right)
+        //    : base(left, right) { }
+        //public Sum(IOperation<double> left, double right)
+        //    : base(left, right) { }
 
-        public Sum(double left, IOperation right)
-            : base(left, right) { }
-        public Sum(double left, IOperation<double> right)
-            : base(left, right) { }
+        //public Sum(double left, IOperation right)
+        //    : base(left, right) { }
+        //public Sum(double left, IOperation<double> right)
+        //    : base(left, right) { }
 
-        public Sum(IOperation left, IOperation right)
-            : base(left, right) { }
-        public Sum(IOperation<double> left, IOperation<double> right)
-            : base(left, right) { }
+        //public Sum(IOperation left, IOperation right)
+        //    : base(left, right) { }
+        //public Sum(IOperation<double> left, IOperation<double> right)
+        //    : base(left, right) { }
 
         protected override char Operator => '+';
 
         public override double Apply(double left, double right)
             => left + right;
 
-        int IResultant<int>.ToResult()
-            => Convert.ToInt32(ToResult());
+        //int IResultant<int>.ToResult()
+        //    => Convert.ToInt32(ToResult());
+        public static implicit operator int(Sum operation)
+            => Convert.ToInt32(operation.ToResult());
 
-        long IResultant<long>.ToResult()
-            => Convert.ToInt64(ToResult());
+        //long IResultant<long>.ToResult()
+        //    => Convert.ToInt64(ToResult());
+        public static implicit operator long(Sum operation)
+            => Convert.ToInt64(operation.ToResult());
+
+        public static implicit operator double(Sum operation)
+            => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/Sum.cs
+++ b/src/Calculator/Implementations/Sum.cs
@@ -1,38 +1,13 @@
-﻿using RamanM.Properti.Calculator.Interfaces;
-using System;
-using System.Reflection.Metadata;
+﻿using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
     /// <summary>
     /// Summation of two operations.
     /// </summary>
-    public class Sum : BinaryOperation<double> //,IResultant<int>, IResultant<long>
+    public class Sum : BinaryOperation<double>
     {
         private Sum() { }
-
-        //public Sum(double left, double right)
-        //    : base(left, right) { }
-
-        //public Sum(IOperation left, double right)
-        //    : base(left, right) { }
-        //public Sum(IOperation<double> left, double right)
-        //    : base(left, right) { }
-
-        //public Sum(double left, IOperation right)
-        //    : base(left, right) { }
-        //public Sum(double left, IOperation<double> right)
-        //    : base(left, right) { }
-
-        //public Sum(IOperation left, IOperation right)
-        //    : base(left, right) { }
-
-        //public Sum(Constant<double> left, Constant<double> right)
-        //{
-        //    Left = left;
-        //    Right = right;
-        //    Parent = null;
-        //}
 
         public Sum(Operation left, Operation right)
             : base(left, right) { }
@@ -42,17 +17,10 @@ namespace RamanM.Properti.Calculator.Implementations
         public override double Apply(double left, double right)
             => left + right;
 
-        //int IResultant<int>.ToResult()
-        //    => Convert.ToInt32(ToResult());
         public static explicit operator int(Sum operation)
             => Convert.ToInt32(operation.ToResult());
 
-        //long IResultant<long>.ToResult()
-        //    => Convert.ToInt64(ToResult());
         public static explicit operator long(Sum operation)
             => Convert.ToInt64(operation.ToResult());
-
-        //public static implicit operator double(Sum operation)
-        //    => operation.ToResult();
     }
 }

--- a/src/Calculator/Implementations/UnaryOperation.cs
+++ b/src/Calculator/Implementations/UnaryOperation.cs
@@ -1,17 +1,16 @@
 ﻿using RamanM.Properti.Calculator.Interfaces;
+using System;
 
 namespace RamanM.Properti.Calculator.Implementations
 {
-    public abstract class UnaryOperation<T> : IUnaryOperation<T>
+    public abstract class UnaryOperation<T> : Operation<T>, IUnaryOperation<T>
         where T : struct
     {
-        protected T? value;
+        //protected T? getter;
 
         protected UnaryOperation()
         {
-            value = null;
-            Operand = null;
-            Parent = null;
+            getter = new Lazy<object>(() => ToResult());
         }
 
         public UnaryOperation(T operand)
@@ -20,14 +19,14 @@ namespace RamanM.Properti.Calculator.Implementations
             Operand = new Constant<T>(operand, this);
         }
 
-        public UnaryOperation(IOperation<T> operation)
+        public UnaryOperation(Operation operation)
             : this()
         {
             Operand = operation;
             Operand.Parent = this;
         }
 
-        public UnaryOperation(IOperation operation)
+        public UnaryOperation(Operation<T> operation)
             : this()
         {
             Operand = operation;
@@ -36,16 +35,16 @@ namespace RamanM.Properti.Calculator.Implementations
 
         public IOperation Operand { get; private set; }
 
-        public IOperation Parent { get; set; }
+        //public IOperation Parent { get; set; }
 
-        public string Print()
+        public override string Print()
         {
             var operand = Operand.Print();
             var format = PrintFormat();
             if (Parent == null)
             {
                 format += " = {2}";
-                T val = value.HasValue ? value.Value : ToResult();
+                T val = /*getter.HasValue ? getter.Value :*/ (T)ToResult();
                 return string.Format(format, operand, Operator, val); // (x!) = y
             }
             return string.Format(format, operand, Operator); // (x!)
@@ -60,13 +59,13 @@ namespace RamanM.Properti.Calculator.Implementations
         /// <returns>A string of format.</returns>
         protected virtual string PrintFormat() => "({0}{1})"; // (x!)
 
-        public string PrintSentence()
+        public override string PrintSentence()
         {
             var operand = Operand.PrintSentence();
             var format = SentenceFormat();
             if (Parent == null)
             {
-                T val = value.HasValue ? value.Value : ToResult();
+                T val = /*getter.HasValue ? getter.Value :*/ (T)ToResult();
                 format += " is {1}";
                 return string.Format(format, operand, val);
             }
@@ -83,14 +82,17 @@ namespace RamanM.Properti.Calculator.Implementations
             return t.Name.ToLower() + " of {0}";
         }
 
-        public T ToResult()
+        public override object ToResult()
         {
-            if (!value.HasValue)
-            {
-                T result = ((IResultant<T>)Operand).ToResult();
-                value = Apply(result);
-            }
-            return value.Value;
+            //if (!getter.HasValue)
+            //{
+            //    T result = ((IResultant<T>)Operand).ToResult();
+            //    getter = Apply(result);
+            //}
+            //return getter.Value;
+            var v = Operand.ToResult();
+            T result = (T)Convert.ChangeType(v, typeof(T));  //((IResultant<T>)Operand).ToResult();
+            return Apply(result);
         }
 
         protected abstract char Operator { get; }

--- a/src/Calculator/Implementations/UnaryOperation.cs
+++ b/src/Calculator/Implementations/UnaryOperation.cs
@@ -6,8 +6,6 @@ namespace RamanM.Properti.Calculator.Implementations
     public abstract class UnaryOperation<T> : Operation<T>, IUnaryOperation<T>
         where T : struct
     {
-        //protected T? getter;
-
         protected UnaryOperation()
         {
             getter = new Lazy<object>(() => ToResult());
@@ -35,8 +33,6 @@ namespace RamanM.Properti.Calculator.Implementations
 
         public IOperation Operand { get; private set; }
 
-        //public IOperation Parent { get; set; }
-
         public override string Print()
         {
             var operand = Operand.Print();
@@ -44,7 +40,7 @@ namespace RamanM.Properti.Calculator.Implementations
             if (Parent == null)
             {
                 format += " = {2}";
-                T val = /*getter.HasValue ? getter.Value :*/ (T)ToResult();
+                T val = (T)ToResult();
                 return string.Format(format, operand, Operator, val); // (x!) = y
             }
             return string.Format(format, operand, Operator); // (x!)
@@ -65,7 +61,7 @@ namespace RamanM.Properti.Calculator.Implementations
             var format = SentenceFormat();
             if (Parent == null)
             {
-                T val = /*getter.HasValue ? getter.Value :*/ (T)ToResult();
+                T val = (T)ToResult();
                 format += " is {1}";
                 return string.Format(format, operand, val);
             }
@@ -84,14 +80,8 @@ namespace RamanM.Properti.Calculator.Implementations
 
         public override object ToResult()
         {
-            //if (!getter.HasValue)
-            //{
-            //    T result = ((IResultant<T>)Operand).ToResult();
-            //    getter = Apply(result);
-            //}
-            //return getter.Value;
             var v = Operand.ToResult();
-            T result = (T)Convert.ChangeType(v, typeof(T));  //((IResultant<T>)Operand).ToResult();
+            T result = (T)Convert.ChangeType(v, typeof(T));
             return Apply(result);
         }
 

--- a/tst/Calculator/Conversion/DivisionConversionTests.cs
+++ b/tst/Calculator/Conversion/DivisionConversionTests.cs
@@ -35,8 +35,8 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Division_FullInterfaceParamsCstr_ReturnsDivisionObject()
         {
             // Arrange
-            IOperation<double> param1 = new Division(3, 1);
-            IOperation<double> param2 = new Division(2, 1);
+            /*IOperation<double>*/ var param1 = new Division(3, 1);
+            /*IOperation<double>*/ var param2 = new Division(2, 1);
 
             // Act
             var sut = new Division(param1, param2);

--- a/tst/Calculator/Conversion/DivisionConversionTests.cs
+++ b/tst/Calculator/Conversion/DivisionConversionTests.cs
@@ -14,21 +14,21 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(5, sut.ToResult());
+            Assert.Equal(5D, sut.ToResult());
         }
 
         [Fact]
         public void Division_MixedDoubleParamsCstr_ReturnsDivisionObject()
         {
             // Arrange, Act
-            var sut = new Division(3, new Constant<double>(2));
-            var sut2 = new Division(new Constant<double>(7), 2);
+            var sut = new Division(3, new Operation<double>(2));
+            var sut2 = new Division(new Operation<double>(7), 2);
 
             // Assert
             Assert.NotNull(sut);
             Assert.NotNull(sut2);
-            Assert.Equal(1.5, sut.ToResult());
-            Assert.Equal(3.5, sut2.ToResult());
+            Assert.Equal(1.5D, sut.ToResult());
+            Assert.Equal(3.5D, sut2.ToResult());
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(1.5, sut.ToResult());
+            Assert.Equal(1.5D, sut.ToResult());
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(2, sut.ToResult());
+            Assert.Equal(2D, sut.ToResult());
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(1.5, sut.ToResult());
+            Assert.Equal(1.5D, sut.ToResult());
         }
 
 
@@ -77,7 +77,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(1.25, sut.ToResult());
+            Assert.Equal(1.25D, sut.ToResult());
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(2, sut.ToResult());
+            Assert.Equal(2D, sut.ToResult());
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(0.5, sut.ToResult());
+            Assert.Equal(0.5D, sut.ToResult());
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(4, sut.ToResult());
+            Assert.Equal(4D, sut.ToResult());
         }
     }
 }

--- a/tst/Calculator/Conversion/FacultyConversionTests.cs
+++ b/tst/Calculator/Conversion/FacultyConversionTests.cs
@@ -32,7 +32,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Faculty_InterfaceParamCstr_ReturnsFacultyObject()
         {
             // Arrange
-            IOperation<long> param = new Constant<long>(2);
+            /*IOperation<long>*/ var param = new Constant<long>(2);
 
             // Act
             var sut = new Faculty(param);

--- a/tst/Calculator/Conversion/FacultyConversionTests.cs
+++ b/tst/Calculator/Conversion/FacultyConversionTests.cs
@@ -14,32 +14,32 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(24, sut.ToResult());
+            Assert.Equal(24L, sut.ToResult());
         }
 
         [Fact]
         public void Faculty_ConstantParamCstr_ReturnsFacultyObject()
         {
             // Arrange, Act
-            var sut = new Faculty(new Constant<long>(3));
+            var sut = new Faculty(new Operation<long>(3));
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(6, sut.ToResult());
+            Assert.Equal(6L, sut.ToResult());
         }
 
         [Fact]
         public void Faculty_InterfaceParamCstr_ReturnsFacultyObject()
         {
             // Arrange
-            /*IOperation<long>*/ var param = new Constant<long>(2);
+            /*IOperation<long>*/ var param = new Operation<long>(2);
 
             // Act
             var sut = new Faculty(param);
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(2, sut.ToResult());
+            Assert.Equal(2L, sut.ToResult());
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(120, sut.ToResult());
+            Assert.Equal(120L, sut.ToResult());
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(6, sut.ToResult());
+            Assert.Equal(6L, sut.ToResult());
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(120, sut.ToResult());
+            Assert.Equal(120L, sut.ToResult());
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(720, sut.ToResult());
+            Assert.Equal(720L, sut.ToResult());
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(120, sut.ToResult());
+            Assert.Equal(120L, sut.ToResult());
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(720, sut.ToResult());
+            Assert.Equal(720L, sut.ToResult());
         }
     }
 }

--- a/tst/Calculator/Conversion/FractionConversionTests.cs
+++ b/tst/Calculator/Conversion/FractionConversionTests.cs
@@ -35,8 +35,8 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Fraction_FullInterfaceParamsCstr_ReturnsFractionObject()
         {
             // Arrange
-            IOperation<int> param1 = new Constant<int>(1);
-            IOperation<int> param2 = new Constant<int>(2);
+            /*IOperation<int>*/ var param1 = new Constant<int>(1);
+            /*IOperation<int>*/ var param2 = new Constant<int>(2);
 
             // Act
             var sut = new Fraction(param1, param2);

--- a/tst/Calculator/Conversion/FractionConversionTests.cs
+++ b/tst/Calculator/Conversion/FractionConversionTests.cs
@@ -21,8 +21,8 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Fraction_MixedDoubleParamsCstr_ReturnsFractionObject()
         {
             // Arrange, Act
-            var sut = new Fraction(1, new Constant<int>(2));
-            var sut2 = new Fraction(new Constant<int>(1), 4);
+            var sut = new Fraction(1, new Operation<int>(2));
+            var sut2 = new Fraction(new Operation<int>(1), 4);
 
             // Assert
             Assert.NotNull(sut);
@@ -35,8 +35,8 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Fraction_FullInterfaceParamsCstr_ReturnsFractionObject()
         {
             // Arrange
-            /*IOperation<int>*/ var param1 = new Constant<int>(1);
-            /*IOperation<int>*/ var param2 = new Constant<int>(2);
+            /*IOperation<int>*/ var param1 = new Operation<int>(1);
+            /*IOperation<int>*/ var param2 = new Operation<int>(2);
 
             // Act
             var sut = new Fraction(param1, param2);

--- a/tst/Calculator/Conversion/MultiplicationConversionTests.cs
+++ b/tst/Calculator/Conversion/MultiplicationConversionTests.cs
@@ -14,21 +14,21 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(15, sut.ToResult());
+            Assert.Equal(15D, sut.ToResult());
         }
 
         [Fact]
         public void Multiplication_MixedDoubleParamsCstr_ReturnsMultiplicationObject()
         {
             // Arrange, Act
-            var sut = new Multiplication(3, new Constant<double>(1));
-            var sut2 = new Multiplication(new Constant<double>(1), 7);
+            var sut = new Multiplication(3, new Operation<double>(1));
+            var sut2 = new Multiplication(new Operation<double>(1), 7);
 
             // Assert
             Assert.NotNull(sut);
             Assert.NotNull(sut2);
-            Assert.Equal(3, sut.ToResult());
-            Assert.Equal(7, sut2.ToResult());
+            Assert.Equal(3D, sut.ToResult());
+            Assert.Equal(7D, sut2.ToResult());
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(48, sut.ToResult());
+            Assert.Equal(48D, sut.ToResult());
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(12, sut.ToResult());
+            Assert.Equal(12D, sut.ToResult());
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(6, sut.ToResult());
+            Assert.Equal(6D, sut.ToResult());
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(12, sut.ToResult());
+            Assert.Equal(12D, sut.ToResult());
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(12, sut.ToResult());
+            Assert.Equal(12D, sut.ToResult());
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(48, sut.ToResult());
+            Assert.Equal(48D, sut.ToResult());
         }
     }
 }

--- a/tst/Calculator/Conversion/MultiplicationConversionTests.cs
+++ b/tst/Calculator/Conversion/MultiplicationConversionTests.cs
@@ -35,8 +35,8 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Multiplication_FullInterfaceParamsCstr_ReturnsMultiplicationObject()
         {
             // Arrange
-            IOperation<double> param1 = new Multiplication(2, 3);
-            IOperation<double> param2 = new Multiplication(2, 4);
+            /*IOperation<double>*/ var param1 = new Multiplication(2, 3);
+            /*IOperation<double>*/ var param2 = new Multiplication(2, 4);
 
             // Act
             var sut = new Multiplication(param1, param2);

--- a/tst/Calculator/Conversion/SubtractionConversionTests.cs
+++ b/tst/Calculator/Conversion/SubtractionConversionTests.cs
@@ -35,8 +35,8 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Subtraction_FullInterfaceParamsCstr_ReturnsSubtractionObject()
         {
             // Arrange
-            IOperation<double> param1 = new Subtraction(5, 2);
-            IOperation<double> param2 = new Subtraction(5, 4);
+            /*IOperation<double>*/ var param1 = new Subtraction(5, 2);
+            /*IOperation<double>*/ var param2 = new Subtraction(5, 4);
 
             // Act
             var sut = new Subtraction(param1, param2);

--- a/tst/Calculator/Conversion/SubtractionConversionTests.cs
+++ b/tst/Calculator/Conversion/SubtractionConversionTests.cs
@@ -14,21 +14,21 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(2, sut.ToResult());
+            Assert.Equal(2D, sut.ToResult());
         }
 
         [Fact]
         public void Subtraction_MixedDoubleParamsCstr_ReturnsSubtractionObject()
         {
             // Arrange, Act
-            var sut = new Subtraction(3, new Constant<double>(1));
-            var sut2 = new Subtraction(new Constant<double>(1), 7);
+            var sut = new Subtraction(3, new Operation<double>(1));
+            var sut2 = new Subtraction(new Operation<double>(1), 7);
 
             // Assert
             Assert.NotNull(sut);
             Assert.NotNull(sut2);
-            Assert.Equal(2, sut.ToResult());
-            Assert.Equal(-6, sut2.ToResult());
+            Assert.Equal(2D, sut.ToResult());
+            Assert.Equal(-6D, sut2.ToResult());
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(2, sut.ToResult());
+            Assert.Equal(2D, sut.ToResult());
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(3, sut.ToResult());
+            Assert.Equal(3D, sut.ToResult());
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(-3, sut.ToResult());
+            Assert.Equal(-3D, sut.ToResult());
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(-4, sut.ToResult());
+            Assert.Equal(-4D, sut.ToResult());
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(2, sut.ToResult());
+            Assert.Equal(2D, sut.ToResult());
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(-18, sut.ToResult());
+            Assert.Equal(-18D, sut.ToResult());
         }
     }
 }

--- a/tst/Calculator/Conversion/SumConversionTests.cs
+++ b/tst/Calculator/Conversion/SumConversionTests.cs
@@ -7,28 +7,39 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
     public class SumConversionTests
     {
         [Fact]
-        public void Sum_DoubleParamsCstr_ReturnsSumObject()
+        public void Sum_IntParamsCstr_ReturnsSumObject()
         {
             // Arrange, Act
             var sut = new Sum(2, 3);
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(5, sut.ToResult());
+            Assert.Equal(5D, sut.ToResult());
+        }
+
+        [Fact]
+        public void Sum_DoubleParamsCstr_ReturnsSumObject()
+        {
+            // Arrange, Act
+            var sut = new Sum(2.5D, 3.0D);
+
+            // Assert
+            Assert.NotNull(sut);
+            Assert.Equal(5.5D, sut.ToResult());
         }
 
         [Fact]
         public void Sum_MixedDoubleParamsCstr_ReturnsSumObject()
         {
             // Arrange, Act
-            var sut = new Sum(2, new Constant<double>(1)); //new Constant<double>(1));
-            var sut2 = new Sum(new Constant<double>(1), 7);
+            var sut = new Sum(2, new Operation(1));
+            var sut2 = new Sum(new Operation(1), 7);
 
             // Assert
             Assert.NotNull(sut);
             Assert.NotNull(sut2);
-            Assert.Equal(3, sut.ToResult());
-            Assert.Equal(8, sut2.ToResult());
+            Assert.Equal(3D, sut.ToResult());
+            Assert.Equal(8D, sut2.ToResult());
         }
 
         [Fact]
@@ -43,7 +54,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(14, sut.ToResult());
+            Assert.Equal(14.0D, sut.ToResult());
         }
 
         [Fact]
@@ -54,7 +65,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(14, sut.ToResult());
+            Assert.Equal(14D, sut.ToResult());
         }
 
         [Fact]
@@ -65,7 +76,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(3, sut.ToResult());
+            Assert.Equal(3D, sut.ToResult());
         }
 
         [Fact]
@@ -76,7 +87,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(16, sut.ToResult());
+            Assert.Equal(16D, sut.ToResult());
         }
 
         [Fact]
@@ -87,7 +98,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(8, sut.ToResult());
+            Assert.Equal(8D, sut.ToResult());
         }
 
         [Fact]
@@ -109,7 +120,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(30, sut.ToResult());
+            Assert.Equal(30D, sut.ToResult());
         }
 
         [Fact]
@@ -120,7 +131,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
 
             // Assert
             Assert.NotNull(sut);
-            Assert.Equal(40321, sut.ToResult());
+            Assert.Equal(40321D, sut.ToResult());
         }
     }
 }

--- a/tst/Calculator/Conversion/SumConversionTests.cs
+++ b/tst/Calculator/Conversion/SumConversionTests.cs
@@ -21,7 +21,7 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Sum_MixedDoubleParamsCstr_ReturnsSumObject()
         {
             // Arrange, Act
-            var sut = new Sum(2, new Constant<double>(1));
+            var sut = new Sum(2, new Constant<double>(1)); //new Constant<double>(1));
             var sut2 = new Sum(new Constant<double>(1), 7);
 
             // Assert
@@ -35,8 +35,8 @@ namespace RamanM.Properti.Calculator.Tests.Conversion
         public void Sum_FullInterfaceParamsCstr_ReturnsSumObject()
         {
             // Arrange
-            IOperation<double> param1 = new Sum(2, 3);
-            IOperation<double> param2 = new Sum(4, 5);
+            /*IOperation<double>*/ var param1 = new Sum(2, 3);
+            /*IOperation<double>*/ var param2 = new Sum(4, 5);
 
             // Act
             var sut = new Sum(param1, param2);

--- a/tst/Calculator/DivisionTests.cs
+++ b/tst/Calculator/DivisionTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 30D, right = 5D;
             var sut = new Division(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"({left} / {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 30D, right = 5D;
             var sut = new Division(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"{nameof(Division).ToLower()} of {left} by {right}";
 
             // Act

--- a/tst/Calculator/DivisionTests.cs
+++ b/tst/Calculator/DivisionTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 30D, right = 5D;
             var sut = new Division(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"({left} / {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 30D, right = 5D;
             var sut = new Division(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"{nameof(Division).ToLower()} of {left} by {right}";
 
             // Act

--- a/tst/Calculator/FacultyTests.cs
+++ b/tst/Calculator/FacultyTests.cs
@@ -41,7 +41,7 @@ namespace RamanM.Properti.Calculator.Tests
         {
             int operand = 4;
             var sut = new Faculty(operand);
-            sut.Parent = new Constant<long>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"({operand}!)";
 
             // Act
@@ -74,7 +74,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             int operand = 4;
             var sut = new Faculty(operand);
-            sut.Parent = new Constant<long>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
 
             string expected = $"{nameof(Faculty).ToLower()} of {operand}";
 

--- a/tst/Calculator/FacultyTests.cs
+++ b/tst/Calculator/FacultyTests.cs
@@ -41,7 +41,7 @@ namespace RamanM.Properti.Calculator.Tests
         {
             int operand = 4;
             var sut = new Faculty(operand);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<long>(sut);
             string expected = $"({operand}!)";
 
             // Act
@@ -74,7 +74,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             int operand = 4;
             var sut = new Faculty(operand);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<long>(sut);
 
             string expected = $"{nameof(Faculty).ToLower()} of {operand}";
 

--- a/tst/Calculator/Fitness/PrintFitnessTests.cs
+++ b/tst/Calculator/Fitness/PrintFitnessTests.cs
@@ -26,7 +26,7 @@ namespace RamanM.Properti.Calculator.Tests.Fitness
         public void Division_Print_ExampleWithSum_PrintsFinalEquality()
         {
             // Arrange
-            var sut = new Division(30, new Sum(2, 3));
+            var sut = new Division(30D, new Sum(2, 3));
             string expected = "(30 / (2 + 3)) = 6";
 
             // Act

--- a/tst/Calculator/FractionTests.cs
+++ b/tst/Calculator/FractionTests.cs
@@ -41,7 +41,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             int left = 2, right = 3;
             var sut = new Fraction(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"({left}/{right})";
 
             // Act
@@ -73,7 +73,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             int left = 2, right = 3;
             var sut = new Fraction(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"{left}/{right}";
 
             // Act

--- a/tst/Calculator/FractionTests.cs
+++ b/tst/Calculator/FractionTests.cs
@@ -41,7 +41,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             int left = 2, right = 3;
             var sut = new Fraction(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"({left}/{right})";
 
             // Act
@@ -73,7 +73,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             int left = 2, right = 3;
             var sut = new Fraction(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"{left}/{right}";
 
             // Act

--- a/tst/Calculator/MultiplicationTests.cs
+++ b/tst/Calculator/MultiplicationTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.0D, right = 1.1D;
             var sut = new Multiplication(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"({left} * {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.0D, right = 1.1D;
             var sut = new Multiplication(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"{nameof(Multiplication).ToLower()} of {left} and {right}";
 
             // Act

--- a/tst/Calculator/MultiplicationTests.cs
+++ b/tst/Calculator/MultiplicationTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.0D, right = 1.1D;
             var sut = new Multiplication(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"({left} * {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.0D, right = 1.1D;
             var sut = new Multiplication(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"{nameof(Multiplication).ToLower()} of {left} and {right}";
 
             // Act

--- a/tst/Calculator/SubtractionTests.cs
+++ b/tst/Calculator/SubtractionTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.5D, right = 1.3D;
             var sut = new Subtraction(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"({left} - {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.5D, right = 1.3D;
             var sut = new Subtraction(left, right);
-            sut.Parent = new Constant(0);
+            sut.Parent = new Constant<double>(sut);
             string expected = $"{nameof(Subtraction).ToLower()} of {left} and {right}";
 
             // Act

--- a/tst/Calculator/SubtractionTests.cs
+++ b/tst/Calculator/SubtractionTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.5D, right = 1.3D;
             var sut = new Subtraction(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"({left} - {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.5D, right = 1.3D;
             var sut = new Subtraction(left, right);
-            sut.Parent = new Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"{nameof(Subtraction).ToLower()} of {left} and {right}";
 
             // Act

--- a/tst/Calculator/SumTests.cs
+++ b/tst/Calculator/SumTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.2D, right = 1.5D;
             var sut = new Sum(left, right);
-            sut.Parent = new Constant(0);
+            //sut.Parent = new Constant(0);
             string expected = $"({left} + {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.2D, right = 1.5D;
             var sut = new Sum(left, right);
-            sut.Parent = new Constant(0);
+            //sut.Parent = new Constant(0);
             string expected = $"{nameof(Sum).ToLower()} of {left} and {right}";
 
             // Act

--- a/tst/Calculator/SumTests.cs
+++ b/tst/Calculator/SumTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.2D, right = 1.5D;
             var sut = new Sum(left, right);
-            sut.Parent = new Operation(() => sut.ToResult()); //Constant<double>(sut);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"({left} + {right})";
 
             // Act

--- a/tst/Calculator/SumTests.cs
+++ b/tst/Calculator/SumTests.cs
@@ -40,7 +40,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.2D, right = 1.5D;
             var sut = new Sum(left, right);
-            //sut.Parent = new Constant(0);
+            sut.Parent = new Operation(() => sut.ToResult()); //Constant<double>(sut);
             string expected = $"({left} + {right})";
 
             // Act
@@ -71,7 +71,7 @@ namespace RamanM.Properti.Calculator.Tests
             // Arrange
             double left = 5.2D, right = 1.5D;
             var sut = new Sum(left, right);
-            //sut.Parent = new Constant(0);
+            sut.Parent = new Operation(() => sut.ToResult());
             string expected = $"{nameof(Sum).ToLower()} of {left} and {right}";
 
             // Act


### PR DESCRIPTION
Hi @mleimerProperti !

This PR is presentation of implemented approach you have suggested me in task #1 regarding benefits of implicit operators for conversions of operations.
Final answer, Yes. This PR demonstrates refactored solution with implicit operators in `Operation` class which constructs `Constant` object from elementary `struct` constant like `double`, `int` and `long`.

---
From your C# sample:
```csharp
public static implicit operator OperationBase(double constant) => new Constant(constant);
```
where
- `OperationBase` is `Operation`
- `Constant` is `Constant<double>`
---
The quote from #1 
> This would allow you to reduce the number of required constructors within each operation-class to as low as one constructor.

Yes, it would! It reduced the number to one!
Every `Operation` class has only one constructor. For example `Sum` has the following constructor only:
```csharp
public Sum(Operation left, Operation right)
    : base(left, right) { }
```
Besides, unary operations will have one constructor too. For example, the `Faculty` class has this public constructor only:
```csharp
public Faculty(Operation operation)
    : base(operation) { }
```

**Finally,**
All implicit operators have been defined in the `Operation` class: [../Calculator/Implementations/Operation.cs, Lines 52-54](https://github.com/raman-m/prop-calc/blob/issue-1-2/src/Calculator/Implementations/Operation.cs#L52)
